### PR TITLE
Added ELIXIR_API to UElixirController class

### DIFF
--- a/Source/Elixir/Private/ElixirController.cpp
+++ b/Source/Elixir/Private/ElixirController.cpp
@@ -1,1 +1,39 @@
 #include "ElixirController.h"
+
+void UElixirController::PrepareElixir(FString GameID, FString DevAPIKey, FString ProdAPIKey)
+{
+#if !UE_BUILD_SHIPPING
+	InternalElixirController::Instance()->PrepareElixir(DevAPIKey, GameID);
+#else
+	InternalElixirController::Instance()->PrepareElixir(ProdAPIKey, GameID);
+#endif
+}
+
+void UElixirController::InitElixir(UObject* WorldContextObject, const FCallback& OnComplete)
+{
+//		InternalElixirController::Instance()->Refresh(WorldContextObject, [WorldContextObject, OnComplete](bool res) {
+//			if (!res)
+	InternalElixirController::Instance()->InitElixir(WorldContextObject, OnComplete);
+//			else
+//				OnComplete.ExecuteIfBound(true); });
+}
+
+void UElixirController::GetUserData(UObject* WorldContextObject, const FUserDataCallback& OnComplete)
+{
+	InternalElixirController::Instance()->GetUserData(WorldContextObject, OnComplete);
+}
+
+void UElixirController::GetCollections(UObject* WorldContextObject, const FCollectionsCallback& OnComplete)
+{
+	InternalElixirController::Instance()->GetCollections(WorldContextObject, OnComplete);
+}
+
+void UElixirController::CloseElixir(UObject* WorldContextObject, const FCallback& OnComplete)
+{
+	InternalElixirController::Instance()->CloseElixir(WorldContextObject, OnComplete);
+}
+
+FString UElixirController::GetToken()
+{
+	return InternalElixirController::Instance()->GetToken();
+}

--- a/Source/Elixir/Public/ElixirController.h
+++ b/Source/Elixir/Public/ElixirController.h
@@ -6,7 +6,7 @@
 #include "ElixirController.generated.h"
 
 UCLASS()
-class UElixirController : public UBlueprintAsyncActionBase
+class ELIXIR_API UElixirController : public UBlueprintAsyncActionBase
 {
 	GENERATED_BODY()
 protected:

--- a/Source/Elixir/Public/ElixirController.h
+++ b/Source/Elixir/Public/ElixirController.h
@@ -43,4 +43,9 @@ public:
 	static void CloseElixir(UObject *WorldContextObject, const FCallback &OnComplete) {
 		InternalElixirController::Instance()->CloseElixir(WorldContextObject, OnComplete);
 	}
+
+	UFUNCTION(BlueprintCallable, Category = "Elixir")
+	static FString GetToken() {
+		return InternalElixirController::Instance()->GetToken();
+	}
 };

--- a/Source/Elixir/Public/ElixirController.h
+++ b/Source/Elixir/Public/ElixirController.h
@@ -12,40 +12,20 @@ class ELIXIR_API UElixirController : public UBlueprintAsyncActionBase
 protected:
 public:
 	UFUNCTION(BlueprintCallable, Category = "Elixir")
-	static void PrepareElixir(FString GameID, FString DevAPIKey, FString ProdAPIKey ) {
-#if !UE_BUILD_SHIPPING
-		InternalElixirController::Instance()->PrepareElixir(DevAPIKey, GameID);
-#else
-		InternalElixirController::Instance()->PrepareElixir(ProdAPIKey, GameID);
-#endif
-	}
+	static void PrepareElixir(FString GameID, FString DevAPIKey, FString ProdAPIKey );
 
 	UFUNCTION(BlueprintCallable, Category = "Elixir", meta = (WorldContext = "WorldContextObject", AutoCreateRefTerm = "OnComplete"))
-	static void InitElixir(UObject *WorldContextObject, const FCallback &OnComplete) {
-		//		InternalElixirController::Instance()->Refresh(WorldContextObject, [WorldContextObject, OnComplete](bool res) {
-		//			if (!res)
-		InternalElixirController::Instance()->InitElixir(WorldContextObject, OnComplete);
-		//			else
-		//				OnComplete.ExecuteIfBound(true); });
-	}
+	static void InitElixir(UObject *WorldContextObject, const FCallback &OnComplete);
 
 	UFUNCTION(BlueprintCallable, Category = "Elixir", meta = (WorldContext = "WorldContextObject", AutoCreateRefTerm = "OnComplete"))
-	static void GetUserData(UObject *WorldContextObject, const FUserDataCallback &OnComplete) {
-		InternalElixirController::Instance()->GetUserData(WorldContextObject, OnComplete);
-	}
+	static void GetUserData(UObject *WorldContextObject, const FUserDataCallback &OnComplete);
 
 	UFUNCTION(BlueprintCallable, Category = "Elixir", meta = (WorldContext = "WorldContextObject", AutoCreateRefTerm = "OnComplete"))
-	static void GetCollections(UObject *WorldContextObject, const FCollectionsCallback &OnComplete) {
-		InternalElixirController::Instance()->GetCollections(WorldContextObject, OnComplete);
-	}
+	static void GetCollections(UObject *WorldContextObject, const FCollectionsCallback &OnComplete);
 
 	UFUNCTION(BlueprintCallable, Category = "Elixir", meta = (WorldContext = "WorldContextObject", AutoCreateRefTerm = "OnComplete"))
-	static void CloseElixir(UObject *WorldContextObject, const FCallback &OnComplete) {
-		InternalElixirController::Instance()->CloseElixir(WorldContextObject, OnComplete);
-	}
+	static void CloseElixir(UObject *WorldContextObject, const FCallback &OnComplete);
 
 	UFUNCTION(BlueprintCallable, Category = "Elixir")
-	static FString GetToken() {
-		return InternalElixirController::Instance()->GetToken();
-	}
+	static FString GetToken();
 };

--- a/Source/Elixir/Public/InternalElixirController.h
+++ b/Source/Elixir/Public/InternalElixirController.h
@@ -100,6 +100,7 @@ private:
 
 public:
 	static InternalElixirController *Instance() { if (!_Instance) _Instance = new InternalElixirController(); return _Instance; }
+	FString GetToken() const { return Token; }
 	void PrepareElixir(FString _APIKey, FString _GameID);
 	void InitElixir(UObject *WorldContextObject, FCallback OnComplete);
 	void GetUserData(UObject *WorldContextObject, FUserDataCallback OnComplete);


### PR DESCRIPTION
UElixirController class must be exported with ELIXIR_API macro in order to use Exlixir SDK within C++ code.