### PR TITLE
Added ELIXIR_API to UElixirController class

### DIFF
--- a/Source/Elixir/Private/ElixirController.cpp
+++ b/Source/Elixir/Private/ElixirController.cpp
@@ -1,1 +1,34 @@
 #include "ElixirController.h"
+
+void UElixirController::PrepareElixir(FString GameID, FString DevAPIKey, FString ProdAPIKey)
+{
+#if !UE_BUILD_SHIPPING
+	InternalElixirController::Instance()->PrepareElixir(DevAPIKey, GameID);
+#else
+	InternalElixirController::Instance()->PrepareElixir(ProdAPIKey, GameID);
+#endif
+}
+
+void UElixirController::InitElixir(UObject* WorldContextObject, const FCallback& OnComplete)
+{
+//		InternalElixirController::Instance()->Refresh(WorldContextObject, [WorldContextObject, OnComplete](bool res) {
+//			if (!res)
+	InternalElixirController::Instance()->InitElixir(WorldContextObject, OnComplete);
+//			else
+//				OnComplete.ExecuteIfBound(true); });
+}
+
+void UElixirController::GetUserData(UObject* WorldContextObject, const FUserDataCallback& OnComplete)
+{
+	InternalElixirController::Instance()->GetUserData(WorldContextObject, OnComplete);
+}
+
+void UElixirController::GetCollections(UObject* WorldContextObject, const FCollectionsCallback& OnComplete)
+{
+	InternalElixirController::Instance()->GetCollections(WorldContextObject, OnComplete);
+}
+
+void UElixirController::CloseElixir(UObject* WorldContextObject, const FCallback& OnComplete)
+{
+	InternalElixirController::Instance()->CloseElixir(WorldContextObject, OnComplete);
+}

--- a/Source/Elixir/Public/ElixirController.cpp
+++ b/Source/Elixir/Public/ElixirController.cpp
@@ -1,1 +1,0 @@
-#include "ElixirController.h"

--- a/Source/Elixir/Public/ElixirController.h
+++ b/Source/Elixir/Public/ElixirController.h
@@ -6,7 +6,7 @@
 #include "ElixirController.generated.h"
 
 UCLASS()
-class UElixirController : public UBlueprintAsyncActionBase
+class ELIXIR_API UElixirController : public UBlueprintAsyncActionBase
 {
 	GENERATED_BODY()
 protected:

--- a/Source/Elixir/Public/ElixirController.h
+++ b/Source/Elixir/Public/ElixirController.h
@@ -12,35 +12,17 @@ class ELIXIR_API UElixirController : public UBlueprintAsyncActionBase
 protected:
 public:
 	UFUNCTION(BlueprintCallable, Category = "Elixir")
-	static void PrepareElixir(FString GameID, FString DevAPIKey, FString ProdAPIKey ) {
-#if !UE_BUILD_SHIPPING
-		InternalElixirController::Instance()->PrepareElixir(DevAPIKey, GameID);
-#else
-		InternalElixirController::Instance()->PrepareElixir(ProdAPIKey, GameID);
-#endif
-	}
+	static void PrepareElixir(FString GameID, FString DevAPIKey, FString ProdAPIKey );
 
 	UFUNCTION(BlueprintCallable, Category = "Elixir", meta = (WorldContext = "WorldContextObject", AutoCreateRefTerm = "OnComplete"))
-	static void InitElixir(UObject *WorldContextObject, const FCallback &OnComplete) {
-		//		InternalElixirController::Instance()->Refresh(WorldContextObject, [WorldContextObject, OnComplete](bool res) {
-		//			if (!res)
-		InternalElixirController::Instance()->InitElixir(WorldContextObject, OnComplete);
-		//			else
-		//				OnComplete.ExecuteIfBound(true); });
-	}
+	static void InitElixir(UObject *WorldContextObject, const FCallback &OnComplete);
 
 	UFUNCTION(BlueprintCallable, Category = "Elixir", meta = (WorldContext = "WorldContextObject", AutoCreateRefTerm = "OnComplete"))
-	static void GetUserData(UObject *WorldContextObject, const FUserDataCallback &OnComplete) {
-		InternalElixirController::Instance()->GetUserData(WorldContextObject, OnComplete);
-	}
+	static void GetUserData(UObject *WorldContextObject, const FUserDataCallback &OnComplete);
 
 	UFUNCTION(BlueprintCallable, Category = "Elixir", meta = (WorldContext = "WorldContextObject", AutoCreateRefTerm = "OnComplete"))
-	static void GetCollections(UObject *WorldContextObject, const FCollectionsCallback &OnComplete) {
-		InternalElixirController::Instance()->GetCollections(WorldContextObject, OnComplete);
-	}
+	static void GetCollections(UObject *WorldContextObject, const FCollectionsCallback &OnComplete);
 
 	UFUNCTION(BlueprintCallable, Category = "Elixir", meta = (WorldContext = "WorldContextObject", AutoCreateRefTerm = "OnComplete"))
-	static void CloseElixir(UObject *WorldContextObject, const FCallback &OnComplete) {
-		InternalElixirController::Instance()->CloseElixir(WorldContextObject, OnComplete);
-	}
+	static void CloseElixir(UObject *WorldContextObject, const FCallback &OnComplete);
 };


### PR DESCRIPTION
1) UElixirController class must be exported with ELIXIR_API macro in order to use Elixir SDK within C++ code.
2) Function implementations must be moved to cpp files to avoid compilation errors on Mac.